### PR TITLE
chore(deps): bump k3s to v1.36.4

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.36.3+k3s1
+k3s_version: v1.36.4+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system


### PR DESCRIPTION
Bump k3s_version to v1.36.4+k3s1 in the sample group_vars.

This is a patch release. kube-vip, kube-vip-cloud-provider, and MetalLB are already at their latest supported versions, so only k3s changes here.